### PR TITLE
Fix card textures not scaling with container

### DIFF
--- a/addons/simple_card_pile_ui/card_ui.gd
+++ b/addons/simple_card_pile_ui/card_ui.gd
@@ -48,13 +48,16 @@ func _ready():
 		return
 	connect("mouse_entered", _on_mouse_enter)
 	connect("mouse_exited", _on_mouse_exited)
-	connect("gui_input", _on_gui_input)
-	if frontface_texture:
-		frontface.texture = load(frontface_texture)
-		backface.texture = load(backface_texture)
-		custom_minimum_size = frontface.texture.get_size()
-		pivot_offset = frontface.texture.get_size() / 2
-		mouse_filter = Control.MOUSE_FILTER_PASS
+        connect("gui_input", _on_gui_input)
+        if frontface_texture:
+                frontface.texture = load(frontface_texture)
+                backface.texture = load(backface_texture)
+                frontface.stretch_mode = TextureRect.STRETCH_SCALE
+                backface.stretch_mode = TextureRect.STRETCH_SCALE
+                frontface.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+                backface.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+                pivot_offset = size / 2
+                mouse_filter = Control.MOUSE_FILTER_PASS
 
 
 
@@ -135,12 +138,12 @@ func get_dropzones(node: Node, className : String, result : Array) -> void:
 		get_dropzones(child, className, result)
 
 func _process(_delta):
-	if is_clicked and drag_when_clicked:
-		target_position = get_global_mouse_position() - custom_minimum_size * 0.5
-	if is_clicked:
-		global_position = target_position
-	elif position != target_position:
-		position = lerp(position, target_position, return_speed)
+        if is_clicked and drag_when_clicked:
+                target_position = get_global_mouse_position() - size * 0.5
+        if is_clicked:
+                global_position = target_position
+        elif position != target_position:
+                position = lerp(position, target_position, return_speed)
 		
 	if Engine.is_editor_hint() and last_child_count != get_child_count():
 		update_configuration_warnings()

--- a/addons/simple_card_pile_ui/card_ui.tscn
+++ b/addons/simple_card_pile_ui/card_ui.tscn
@@ -7,12 +7,22 @@ layout_mode = 3
 anchors_preset = 0
 script = ExtResource("1_v1sf0")
 
-[node name="BackFaceTextureRect" type="TextureRect" parent="."]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+[node name="Backface" type="TextureRect" parent="."]
+layout_mode = 3
+anchors_preset = 15
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+expand_mode = 1
+stretch_mode = 0
 
-[node name="FrontFaceTextureRect" type="TextureRect" parent="."]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+[node name="Frontface" type="TextureRect" parent="."]
+layout_mode = 3
+anchors_preset = 15
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+expand_mode = 1
+stretch_mode = 0

--- a/card_ui.tscn
+++ b/card_ui.tscn
@@ -16,11 +16,21 @@ script = ExtResource("1_kvb7q")
 card_data = SubResource("Resource_bjyew")
 
 [node name="Frontface" type="TextureRect" parent="."]
-layout_mode = 0
-offset_right = 10.0
-offset_bottom = 10.0
+layout_mode = 3
+anchors_preset = 15
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+expand_mode = 1
+stretch_mode = 0
 
 [node name="Backface" type="TextureRect" parent="."]
-layout_mode = 0
-offset_right = 10.0
-offset_bottom = 10.0
+layout_mode = 3
+anchors_preset = 15
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+expand_mode = 1
+stretch_mode = 0


### PR DESCRIPTION
## Summary
- Ensure card textures fill their Control and ignore original pixel size
- Use node size for drag positioning so cards move correctly when scaled
- Anchor front and back textures to scale with their parent controls

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `godot4 --headless -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950b7b3618832fb24f7341d2c00fbb